### PR TITLE
Fixes ScaleShowTransition & ScaleHideTransition inits not being public

### DIFF
--- a/scaletransitiondemo/ScaleTransition/ScaleTransition.swift
+++ b/scaletransitiondemo/ScaleTransition/ScaleTransition.swift
@@ -33,7 +33,7 @@ public class ScaleShowTransition: NSObject, Animations {
   let duration:   Double
   let scaleValue: Double
     
-  init (duration: Double, scale: Double) {
+  public init (duration: Double, scale: Double) {
     self.duration   = duration
     self.scaleValue = scale
   }
@@ -97,7 +97,7 @@ public class ScaleHideTransition: NSObject, Animations {
   let duration  : Double
   let scaleValue: Double
   
-  init (duration: Double, scale: Double) {
+  public init (duration: Double, scale: Double) {
     self.duration   = duration
     self.scaleValue = scale
   }


### PR DESCRIPTION
In types with access level higher than `internal`, functions without explicit access designator will be marked as `internal` implicitly.
